### PR TITLE
Add ability to provide custom module names

### DIFF
--- a/lib/ES6ModuleFile.js
+++ b/lib/ES6ModuleFile.js
@@ -18,14 +18,11 @@ function ES6ModuleFile(opts) {
 
 _.extend(ES6ModuleFile.prototype, {
     analyzeFile: function (filePath) {
-        var self = this,
-            name = path.relative(this.opts.cwd, filePath);
-
-        name = path.join(path.dirname(name), path.basename(name, this.opts.extension));
-
         return readFile(filePath).then(function (contents) {
-            return self.analyzeContents(contents, name, filePath);
-        });
+            var name = this.getModuleName(filePath);
+
+            return this.analyzeContents(contents, name, filePath);
+        }.bind(this));
     },
 
     analyzeContents: function (contents, name, filePath) {
@@ -82,14 +79,24 @@ _.extend(ES6ModuleFile.prototype, {
         });
     },
 
+    getModuleName: function (filePath) {
+        // By default use the relative path (without extension) from the cwd.
+        var name = path.relative(this.opts.cwd, filePath);
+
+        return path.join(path.dirname(name), path.basename(name, this.opts.extension));
+    },
+
     getContentsSyntaxTree: function (contents) {
         return Promise.resolve(esprima.parse(contents));
     }
 });
 
 ES6ModuleFile.analyzeFiles = function (files, opts) {
+    opts = _.defaults(opts || {}, {
+        ES6ModuleFile: ES6ModuleFile
+    });
     return Promise.reduce(files, function (result, fileName) {
-        return new ES6ModuleFile(opts).analyzeFile(fileName).then(function (info) {
+        return new opts.ES6ModuleFile(opts).analyzeFile(fileName).then(function (info) {
             result[info.name] = info;
 
             return result;

--- a/test/fixtures/renamed/bar.js
+++ b/test/fixtures/renamed/bar.js
@@ -1,0 +1,10 @@
+
+import foo from 'appkit/foo';
+
+var bar = {
+	property: true
+};
+
+export { bar };
+
+export default bar;

--- a/test/fixtures/renamed/baz.js
+++ b/test/fixtures/renamed/baz.js
@@ -1,0 +1,13 @@
+
+import { missing } from 'appkit/foo';
+import { bar } from 'appkit/bar';
+
+var bim = {
+	property: true
+};
+
+export var baz = bim;
+
+export { bim };
+
+export default { bim: bim, baz: baz };

--- a/test/fixtures/renamed/foo.js
+++ b/test/fixtures/renamed/foo.js
@@ -1,0 +1,6 @@
+
+var foo = {
+	property: true
+};
+
+export default foo;


### PR DESCRIPTION
- Refactor name resolution into getModuleName
- Allow passing in custom ES6Module file to analyze

For supporting situations like stefanpenner/ember-app-kit#500 in grunt-es6-import-validate.
