### PR TITLE
Fix for export function named() { ... } statements

### DIFF
--- a/lib/ES6ModuleFile.js
+++ b/lib/ES6ModuleFile.js
@@ -30,14 +30,12 @@ _.extend(ES6ModuleFile.prototype, {
 
         return this.getContentsSyntaxTree(contents).then(function (syntax) {
             var info = {
-                name: name,
-                filePath: filePath || name,
-                imports: [],
-                exports: []
-            };
-
-            return _.reduce(syntax.body, function (info, token) {
-                if (token.type === 'ImportDeclaration') {
+                    name: name,
+                    filePath: filePath || name,
+                    imports: [],
+                    exports: []
+                },
+                handleImportToken = function (token) {
                     if (token.kind === 'named') {
                         _.each(token.specifiers, function (specifier) {
                             // Add imports for each named import
@@ -53,7 +51,8 @@ _.extend(ES6ModuleFile.prototype, {
                             from: token.source.value
                         });
                     }
-                } else if (token.type === 'ExportDeclaration') {
+                },
+                handleExportToken = function (token) {
                     if (token.specifiers) {
                         // Add each named export
                         _.each(token.specifiers, function (specifier) {
@@ -64,14 +63,30 @@ _.extend(ES6ModuleFile.prototype, {
                     } else if (token.declaration) {
                         // Handle export var blah = bar;
                         // And export default bar;
+                        // And export function blah() { ... }
                         var decls = token.declaration.declarations || token.declaration;
 
-                        _.each(decls, function (decl) {
+                        // Check for token.declaration case; FunctionDeclarataion
+                        if (_.isObject(decls) && decls.id) {
+                            // Handles export function blah() { ... }
                             info.exports.push({
-                                name: decl.id.name
+                                name: decls.id.name
                             });
-                        });
+                        } else if (_.isArray(decls)) {
+                            _.each(decls, function (decl) {
+                                info.exports.push({
+                                    name: decl.id.name
+                                });
+                            });
+                        }
                     }
+                };
+
+            return _.reduce(syntax.body, function (info, token) {
+                if (token.type === 'ImportDeclaration') {
+                    handleImportToken(token);
+                } else if (token.type === 'ExportDeclaration') {
+                    handleExportToken(token);
                 }
 
                 return info;

--- a/test/all_spec.js
+++ b/test/all_spec.js
@@ -48,6 +48,34 @@ describe('ES6ModuleFile', function () {
             });
     });
 
+    it('reads a file and returns imports/exports info with named function exports', function (done) {
+        var file = new ES6ModuleFile({
+            cwd: path.join(__dirname, 'fixtures')
+        });
+
+        file.analyzeFile(path.join(__dirname, 'fixtures', 'foo.js'))
+            .then(function (info) {
+                should.exist(info.name);
+                should.exist(info.imports);
+                should.exist(info.exports);
+
+                info.name.should.equal('foo');
+
+                info.filePath.should.equal(path.join(file.opts.cwd, 'foo.js'));
+
+                info.imports.length.should.equal(0);
+                
+                info.exports.length.should.equal(2);
+                info.exports[0].name.should.equal('namedFoo');
+                info.exports[1].name.should.equal('default');
+
+                done();
+            })
+            .catch(function (err) {
+                done(err);
+            });
+    });
+
     it('takes a list of files and analyzes them in bulk', function (done) {
         var cwd = path.join(__dirname, 'fixtures'),
             files = [
@@ -64,7 +92,7 @@ describe('ES6ModuleFile', function () {
                 should.exist(result.baz);
 
                 result.foo.imports.length.should.equal(0);
-                result.foo.exports.length.should.equal(1);
+                result.foo.exports.length.should.equal(2);
 
                 result.bar.imports.length.should.equal(1);
                 result.bar.exports.length.should.equal(2);

--- a/test/fixtures/foo.js
+++ b/test/fixtures/foo.js
@@ -3,4 +3,8 @@ var foo = {
 	property: true
 };
 
+export function namedFoo() {
+	return 42;
+}
+
 export default foo;


### PR DESCRIPTION
- Update foo.js fixture to have a named function export
- Update test to make sure named function export is present
- Update logic for export declarations for FunctionDeclaration case
- Split out import and export token handlers to reduce complexity
