### PR TITLE
Fix for windows backslash paths

### DIFF
--- a/lib/ES6ModuleFile.js
+++ b/lib/ES6ModuleFile.js
@@ -93,9 +93,17 @@ _.extend(ES6ModuleFile.prototype, {
 
     getModuleName: function (filePath) {
         // By default use the relative path (without extension) from the cwd.
-        var name = path.relative(this.opts.cwd, filePath);
+        var name = this.getNameFromPath(filePath);
+
+        // Normalize for windoze
+        name = name.replace(/\\/g, '/');
 
         return path.join(path.dirname(name), path.basename(name, this.opts.extension));
+    },
+
+    // Only broken out to stub for windows backslash in tests
+    getNameFromPath: function (filePath) {
+        return path.relative(this.opts.cwd, filePath);
     },
 
     getContentsSyntaxTree: function (contents) {

--- a/test/fixtures/renamed/bar.js
+++ b/test/fixtures/renamed/bar.js
@@ -1,8 +1,10 @@
 
 import foo from 'appkit/foo';
+import thing from 'appkit/nested/thing';
 
 var bar = {
-	property: true
+	property: true,
+	thing: thing
 };
 
 export { bar };

--- a/test/fixtures/renamed/nested/thing.js
+++ b/test/fixtures/renamed/nested/thing.js
@@ -1,0 +1,4 @@
+export default {
+	one: 1,
+	two: '2'
+};


### PR DESCRIPTION
- Replace \ with / after getting relative path
- Move path.relative call to its own function for stubbing
- Add test with backslashes in file paths

Reported in stefanpenner/ember-app-kit#525
