### PR TITLE
Support relative paths for imported modules

### DIFF
--- a/lib/ES6ModuleFile.js
+++ b/lib/ES6ModuleFile.js
@@ -23,6 +23,7 @@ _.extend(ES6ModuleFile.prototype, {
     },
 
     analyzeContents: function (contents, name, filePath) {
+        // TODO: This method is getting pretty big, consider refactoring to smaller parts
         var self = this;
 
         return this.getContentsSyntaxTree(contents).then(function (syntax) {
@@ -34,20 +35,32 @@ _.extend(ES6ModuleFile.prototype, {
                     imports: [],
                     exports: []
                 },
+                getFromModule = function (fromValue) {
+                    var fromPath;
+
+                    // If it's a relative path, resolve it to a consistent name
+                    if (fromValue[0] === '.') {
+                        fromPath = path.resolve(path.dirname(filePath), fromValue);
+                        return self.getModuleName(fromPath);
+                    }
+
+                    return fromValue;
+                },
                 handleImportToken = function (token) {
+                    var fromModuleName = getFromModule(token.source.value);
                     if (token.kind === 'named') {
                         _.each(token.specifiers, function (specifier) {
                             // Add imports for each named import
                             info.imports.push({
                                 name: specifier.id.name,
-                                from: token.source.value
+                                from: fromModuleName
                             });
                         });
                     } else {
                         // Add import just for default
                         info.imports.push({
                             name: 'default',
-                            from: token.source.value
+                            from: fromModuleName
                         });
                     }
                 },

--- a/test/all_spec.js
+++ b/test/all_spec.js
@@ -281,4 +281,42 @@ describe('ES6ModuleFile', function () {
                 done(err);
             });
     });
+
+    it('handles relative paths', function (done) {
+        var cwd = path.join(__dirname, 'fixtures', 'relative'),
+            files = [
+                path.join(cwd, 'some', 'module1.js'),
+                path.join(cwd, 'other', 'module2.js'),
+                path.join(cwd, 'more', 'module3.js'),
+                path.join(cwd, 'more', 'module4.js')
+            ];
+
+        ES6ModuleFile.validateImports(files, { 
+                cwd: cwd
+            })
+            .then(function (result) {
+                should.exist(result);
+                should.exist(result['some/module1']);
+                should.exist(result['other/module2']);
+                should.exist(result['more/module3']);
+                should.exist(result['more/module4']);
+
+                result['some/module1'].imports.length.should.equal(2);
+                result['some/module1'].imports[0].from.should.equal('other/module2');
+
+                result['other/module2'].imports.length.should.equal(1);
+                result['other/module2'].imports[0].from.should.equal('more/module4');
+
+                result['more/module3'].imports.length.should.equal(1);
+                result['more/module3'].imports[0].from.should.equal('more/module4');
+
+                result['more/module4'].imports.length.should.equal(0);
+
+                done();
+            })
+            .catch(function (err) {
+                console.log(err);
+                done(err);
+            });
+    });
 });

--- a/test/fixtures/relative/more/module3.js
+++ b/test/fixtures/relative/more/module3.js
@@ -1,0 +1,6 @@
+
+import Module4 from './module4';
+
+export default {
+	Module4: Module4
+};

--- a/test/fixtures/relative/more/module4.js
+++ b/test/fixtures/relative/more/module4.js
@@ -1,0 +1,6 @@
+
+export default {
+	four: function () {
+		return 4;
+	}
+};

--- a/test/fixtures/relative/other/module2.js
+++ b/test/fixtures/relative/other/module2.js
@@ -1,0 +1,4 @@
+
+import Module4 from '../more/module4';
+
+export default "Module2";

--- a/test/fixtures/relative/some/module1.js
+++ b/test/fixtures/relative/some/module1.js
@@ -1,0 +1,8 @@
+
+import Module2 from '../other/module2';
+import Module3 from '../more/module3';
+
+export default {
+	Module2: Module2,
+	Module3: Module3
+};


### PR DESCRIPTION
Closes #8 
- Naive relative path detection by leading '.'
- Automatically parse from module name during analyze
- Add unit test and fixtures with relative paths
